### PR TITLE
Feature/apply redux: Redux Store에 redux-persist 적용 및 상태 복원 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-router-dom": "^7.0.1",
         "react-scripts": "5.0.1",
         "react-slick": "^0.30.2",
+        "redux-persist": "^6.0.0",
         "slick-carousel": "^1.8.1",
         "swiper": "^11.1.15",
         "web-vitals": "^2.1.4"
@@ -15745,6 +15746,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^7.0.1",
     "react-scripts": "5.0.1",
     "react-slick": "^0.30.2",
+    "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
     "swiper": "^11.1.15",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,8 @@ import SuccessPage from "./pages/register/success/SuccessPage";
 import ReportPage from "./pages/register/report/ReportPage";
 import DetailPage from "./pages/detail/DetailPage";
 import { Provider } from "react-redux"; // Provider 임포트
-import store from "./redux/store.js"; // Redux Store 임포트
+import store, { persistor } from './redux/store'; // Store와 Persistor 가져오기
+import { PersistGate } from 'redux-persist/integration/react'; // PersistGate 추가
 
 // WebP 감지 로직
 const detectWebP = () => {
@@ -47,9 +48,12 @@ function App() {
 
   return (
     <Provider store={store}> {/* Redux Store 제공 */}
-      <BrowserRouter>
-        <AppContent isWebPSupported={isWebPSupported} />
-      </BrowserRouter>
+      {/* Redux 상태 복원을 위한 PersistGate */}
+      <PersistGate loading={null} persistor={persistor}>
+        <BrowserRouter>
+          <AppContent isWebPSupported={isWebPSupported} />
+        </BrowserRouter>
+      </PersistGate>
     </Provider>
   );
 }

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,11 +1,24 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { persistStore, persistReducer } from 'redux-persist'; // redux-persist를 위한 모듈 가져오기
+import storage from 'redux-persist/lib/storage'; // Local Storage를 사용
 import userReducer from './slices/user'; // 닉네임 관리 Slice 가져오기
+
+// redux-persist 설정
+const persistConfig = {
+  key: 'user', // 저장될 key 이름
+  storage, // Local Storage를 사용
+};
+
+// userReducer를 persistReducer로 래핑
+const persistedReducer = persistReducer(persistConfig, userReducer);
 
 // Redux Store 생성
 const store = configureStore({
   reducer: {
-    user: userReducer, // 닉네임 상태를 Redux Store에 등록
+    user: persistedReducer, // Persist된 Reducer 등록
   },
 });
 
-export default store; // Store를 내보내기
+// Persistor 생성: 상태 저장 및 복원을 관리
+export const persistor = persistStore(store);
+export default store;


### PR DESCRIPTION
Redux Store에 redux-persist를 적용하여 새로고침 시 Redux 상태를 유지하는 기능을 추가.
닉네임 상태가 새로고침 후에도 유지되도록 함.

- redux-persist 의존성 추가
- Redux Store를 persistReducer로 감싸 상태를 Local Storage에 저장
- PersistGate를 App.js에 적용하여 상태 복원 처리
- userReducer의 초기 로직은 수정하지 않고, Local Storage와 연동되도록 설정