### PR TITLE
[fix] 서버 데이터 변경에 따른 JSON.parse 제거 및 date 필드명 수정

### DIFF
--- a/src/pages/detail/DetailPage.js
+++ b/src/pages/detail/DetailPage.js
@@ -24,12 +24,10 @@ function DetailsPage() {
         const detailResponse = await fetchDetailPageData(id); // 상세 APi
         setDetailData(detailResponse.data); // 서버에서 받은 데이터의 "data"만 저장
 
-        const jsonString = detailResponse.data.flavors;
-        // 문자열을 객체 배열로 변환
-        const jsonObjectArray = JSON.parse(jsonString);
-        setEatenFlavors(jsonObjectArray);
+        const flavorsArray = detailResponse.data.flavors;
+        setEatenFlavors(flavorsArray);
 
-        const dateString = detailResponse.data.date; // 서버에서 받은 날짜 문자열
+        const dateString = detailResponse.data.regDate; // 서버에서 받은 날짜 문자열
         const dateObject = new Date(dateString); // 문자열을 Date 객체로 변환
         setDate(dateObject); // 상태에 저장
 


### PR DESCRIPTION
- 서버에서 제공하는 `flavors` 데이터가 배열 형태로 전달되도록 변경되어 불필요한 `JSON.parse` 제거
- 서버 데이터 필드명이 `date`에서 `regDate`로 변경됨에 따라 해당 부분 수정