### PR TITLE
[feat] 캘린더에서 과거 날짜 선택 및 등록 기능 추가

### DIFF
--- a/src/pages/calendar/CalendarPage.js
+++ b/src/pages/calendar/CalendarPage.js
@@ -22,8 +22,9 @@ function CalendarPage() {
   // 서버로부터 데이터를 가져오는 함수
   const fetchData = async (year, month) => {
     try {
-      const response = await fetchCalendarPageData(`${year}-${month}`);
-      const dates = response.data.map((item) => item.regDate);
+      const formattedMonth = String(month).padStart(2, "0"); // 여기서 문자열 변환
+      const response = await fetchCalendarPageData(`${year}-${formattedMonth}`);
+      const dates = response.data.map((item) => item.date);
       // 날짜를 YYYY-MM-DD 형태로 변환
       const formattedDates = dates.map((dateString) => {
         const date = new Date(dateString); // 문자열을 Date 객체로 변환
@@ -51,18 +52,27 @@ function CalendarPage() {
   // 달력의 현재 활성화된 날짜 변경 핸들러
   const handleActiveStartDateChange = ({ activeStartDate }) => {
     const year = activeStartDate.getFullYear();
-    const month = activeStartDate.getMonth() + 1;
-    setCurrentMonth({ year, month });
+    const month = String(activeStartDate.getMonth() + 1).padStart(2, "0"); // 여기서 month를 문자열로 변환
+    setCurrentMonth({ year, month }); // 이제 month가 "01" ~ "09" 형식으로 저장됨
   };
 
   const handleDateChange = (date) => {
     const formattedDate = moment(date).format("YYYY-MM-DD");
     setValue(formattedDate);
     const selectedDate = specialDates.find(
-      (item) => item.regDate.split("T")[0] === formattedDate
+      (item) => item.date.split("T")[0] === formattedDate
     );
     if (selectedDate) {
       navigate(`/detail/${selectedDate.id}`);
+    } else {
+      // 오늘 날짜와 비교
+      const today = moment().startOf("day"); // 오늘 날짜
+      const selectedMoment = moment(date).startOf("day"); // 선택한 날짜
+
+      if (selectedMoment.isSameOrBefore(today)) {
+        // 선택 날짜가 오늘 또는 오늘 이전이면 등록 페이지로 이동
+        navigate(`/register/addPage?date=${formattedDate}`);
+      }
     }
   };
 

--- a/src/pages/detail/DetailPage.js
+++ b/src/pages/detail/DetailPage.js
@@ -27,7 +27,7 @@ function DetailsPage() {
         const flavorsArray = detailResponse.data.flavors;
         setEatenFlavors(flavorsArray);
 
-        const dateString = detailResponse.data.regDate; // 서버에서 받은 날짜 문자열
+        const dateString = detailResponse.data.date; // 서버에서 받은 날짜 문자열
         const dateObject = new Date(dateString); // 문자열을 Date 객체로 변환
         setDate(dateObject); // 상태에 저장
 

--- a/src/pages/register/add/AddPage.js
+++ b/src/pages/register/add/AddPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import ImageUpload from "../../../components/imageUpload/ImageUpload";
 import DropdownSelector from "../../../components/dropdownSelector/DropdownSelector";
 import { fetchFlavorData, postRegisterData } from "../../../api/service.js";
@@ -10,9 +10,24 @@ const AddPage = () => {
   const [selectedOptions, setSelectedOptions] = useState({}); // 선택된 옵션 객체
   const [flavors, setFlavors] = useState([]); // data 값만 저장
   const [flavorsList, setFlavorsList] = useState([]); // data 값만 저장
-
+  const [dateToSend, setDateToSend] = useState(""); // 서버로 전송할 날짜 저장
   const dispatch = useDispatch(); // Redux 디스패치
   const navigate = useNavigate();
+  const location = useLocation(); // URL 파라미터 가져오기
+
+  // URL 파라미터에서 날짜 가져오기
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+    const paramDate = queryParams.get("date");
+
+    if (paramDate) {
+      setDateToSend(paramDate); // URL 파라미터로 전달된 날짜를 사용
+    } else {
+      const today = new Date();
+      const formattedToday = today.toISOString().split("T")[0]; // 오늘 날짜를 "YYYY-MM-DD" 형식으로 변환
+      setDateToSend(formattedToday); // 오늘 날짜를 기본값으로 설정
+    }
+  }, [location]);
 
   useEffect(() => {
     const getFlavors = async () => {
@@ -83,7 +98,7 @@ const AddPage = () => {
     });
   };
 
-  //서버로 보내기 (나중에 수정)
+  //서버로 보내기
   const handleSubmit = async () => {
     if (!Object.keys(selectedOptions).length) {
       alert("옵션을 선택해주세요.");
@@ -113,6 +128,7 @@ const AddPage = () => {
       .filter(Boolean); // null 값 제거
 
     formData.append("flavors", JSON.stringify(flavorsToSend));
+    formData.append("date", dateToSend);
 
     try {
       const result = await postRegisterData(formData);


### PR DESCRIPTION
- 캘린더에서 오늘, 오늘 이전 날짜도 선택 가능하도록 수정
- 선택한 날짜를 등록 페이지에서 반영할 수 있도록 dateToSend 추가
- 서버로 보낼 월(month)을 항상 01~09 형식으로 유지하도록 수정
- 서버에서 받아오는 regDate → date 변경 사항 반영
