### PR TITLE
[Fix] 서버 응답 daysInWeek가 null인 경우 빈 객체({})로 초기화하도록 수정

### DIFF
--- a/src/pages/main/MainPage.js
+++ b/src/pages/main/MainPage.js
@@ -44,7 +44,8 @@ function FishFrame() {
       try {
         const response = await fetchMainPageData(); // 서버 데이터 가져오기
 
-        setEatenDays(response.data.daysInWeek);
+        // daysInWeek가 null 이면 빈 객체를 사용
+        setEatenDays(response.data.daysInWeek || {});
       } catch (error) {
         console.error("데이터 가져오기 실패:", error);
         // alert("서버로부터 데이터를 가져오는 데 실패했습니다.");


### PR DESCRIPTION
- 서버에서 받아온 daysInWeek 값이 null일 때, 빈 객체({})를 기본값으로 설정하여 이후 로직에서 에러 발생 방지