### PR TITLE
붕어빵 도감 상세보기(BookDetailPage) 기능 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import SuccessPage from "./pages/register/success/SuccessPage";
 import ReportPage from "./pages/register/report/ReportPage";
 import DetailPage from "./pages/detail/DetailPage";
 import BungBalGamePage from "./pages/game/bungBalGamePage";
+import BookDetailPage from './pages/bookDetail/BookDetailPage';
 import { Provider } from "react-redux"; // Provider 임포트
 import store, { persistor } from "./redux/store"; // Store와 Persistor 가져오기
 import { PersistGate } from "redux-persist/integration/react"; // PersistGate 추가
@@ -88,6 +89,14 @@ function AppContent({ isWebPSupported }) {
           element={
             <ProtectedRoute>
               <BookPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/bookDetailPage/:flavorId"
+          element={
+            <ProtectedRoute>
+              <BookDetailPage />
             </ProtectedRoute>
           }
         />

--- a/src/api/service.js
+++ b/src/api/service.js
@@ -74,6 +74,16 @@ export async function fetchFlavorData() {
   }
 }
 
+export async function fetchBookDetailData(flavorId) {
+  try {
+    const response = await axiosInstance.get(`/fish-bun/book/detail/${flavorId}`);
+    return response.data;
+  } catch (error) {
+    console.error("데이터 요청 실패:", error);
+    throw error;
+  }
+}
+
 //post
 export async function postNickNameAddData(nickname) {
   try {

--- a/src/components/Buttons/CloseButton.js
+++ b/src/components/Buttons/CloseButton.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const CloseButton = ({ onClick, className = "" }) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`absolute top-6 right-6 w-8 h-8 rounded-full flex items-center justify-center bg-[#1069b0] hover:bg-gray-300 ${className}`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth="1.5"
+        stroke="currentColor"
+        className="w-6 h-6 text-white stroke-[3px]"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+};
+
+export default CloseButton;

--- a/src/pages/book/BookPage.js
+++ b/src/pages/book/BookPage.js
@@ -92,6 +92,12 @@ function BookPage() {
     chunkedFlavors.push(flavors.slice(i, i + 9));
   }
 
+  const goToFishDetail = (fishId) => {
+    return () => {
+      navigate(`/bookDetailPage/${fishId}`);
+    }
+  }
+
   return (
     <div className="w-full flex-grow flex flex-col">
       <div className="w-full h-max">
@@ -138,11 +144,11 @@ function BookPage() {
                     {page.map((fish) => (
                       <div
                         key={fish.id}
-                        className={`flex flex-col items-center justify-center h-max ${
-                          collectedFish.includes(fish.id)
-                            ? "opacity-100"
-                            : "opacity-25"
-                        }`}
+                        className={`flex flex-col items-center justify-center h-max ${collectedFish.includes(fish.id)
+                          ? "opacity-100"
+                          : "opacity-25"
+                          }`}
+                        onClick={goToFishDetail(fish.id)}
                       >
                         <img
                           src={`/assets/webp/flavorIcons/${fish.iconCode}.webp`}

--- a/src/pages/bookDetail/BookDetailPage.js
+++ b/src/pages/bookDetail/BookDetailPage.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+import { fetchBookDetailData } from "../../api/service.js";
+import { useParams, useNavigate } from "react-router-dom";
+import CloseButton from './../../components/Buttons/CloseButton';
+
+const BookDetailPage = () => {
+  const { flavorId } = useParams(); // URL에서 flavorId 가져오기
+  const [dateList, setDateList] = useState([]); // 날짜별 데이터 저장
+  const [fishBunFlavor, setFishBunFlavor] = useState(null); // 붕어빵 맛 데이터 저장
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetchBookDetailData(flavorId);
+
+        if (response.result === "success" && response.statusCode === "200") {
+          setDateList(response.data.dateList); // 날짜별 데이터 저장
+          setFishBunFlavor(response.data.fishBunFlavor); // 붕어빵 맛 데이터 저장
+        } else {
+          console.error("서버 응답 실패:", response);
+          alert("데이터를 가져오는 데 실패했습니다.");
+        }
+      } catch (error) {
+        console.error("데이터 가져오기 실패:", error);
+        alert("서버로부터 데이터를 가져오는 데 실패했습니다.");
+      }
+    };
+
+    if (flavorId) {
+      fetchData();
+    }
+  }, [flavorId]); // flavorId가 변경될 때마다 실행
+
+  const handleClose = () => {
+    //메인 페이지로 네비게이트
+    navigate(-1);
+  };
+
+  return (
+    <div className="w-full flex-grow flex flex-col overflow-y-auto">
+      <div className="w-full h-max">
+        <img src="/assets/webp/paperOnCheckT.webp" alt="상단 배너" />
+      </div>
+      <CloseButton onClick={handleClose} />
+      <div
+        className="items-center justify-center px-4"
+        style={{ backgroundImage: "url('/assets/webp/paperOnCheckB.webp')" }}>
+        {fishBunFlavor ? (
+          <div className="py-4 w-full">
+            <div className="text-center text-sz40 pb-1">{fishBunFlavor.flavor}</div>
+            {/* 하이라이트 */}
+            <div className="text-center text-sz22 text-yellow-600 px-6">{fishBunFlavor.highlight}</div>
+
+            <div className="w-full px-6 py-2">
+              {/* 이미지 */}
+              <div className="flex justify-center pt-4">
+                <img
+                  src={`/assets/webp/flavorIcons/${fishBunFlavor.iconCode}.webp`}
+                  alt={fishBunFlavor.flavor}
+                  className="w-40 h-40 object-cover"
+                  onError={(e) => {
+                    e.target.src = "/assets/webp/flavorIcons/notYet.webp"; // 이미지 로드 실패 시 기본 이미지로 대체
+                  }}
+                />
+              </div>
+
+              {/* 설명 */}
+              <div className="px-5 pt-2 text-gray-700 text-justify text-sz22 whitespace-pre-line break-all">{fishBunFlavor.description}</div>
+            </div>
+
+            {/* 날짜별 데이터 */}
+            <div className="mt-6">
+              <div className="text-center text-sz30">발견 날짜</div>
+              <ul className="mt-2 text-center text-sz20">
+                {dateList.map((item, index) => (
+                  <div
+                    key={index}
+                    className="rounded-lg shadow-lg border-2 px-6 p-3 my-2 flex justify-between w-[80%] items-center mx-auto text-center transition transform active:scale-95 active:bg-blue-100"
+                    onClick={() => navigate(`/detail/${item.id}`)}
+                  >
+                    <span className="text-sz25">
+                      {item.date.split('-')[0]}년 {item.date.split('-')[1]}월 {item.date.split('-')[2]}일
+                    </span>
+                    <span className="text-sz25 text-yellow-600">{item.count}개</span>
+                  </div>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <p className="text-center text-gray-500">붕어빵 정보를 불러오는 중...</p>
+        )
+        }
+      </div >
+    </div >
+  );
+};
+
+export default BookDetailPage;


### PR DESCRIPTION
**pr 내용**
- BookDetailPage 추가 및 붕어빵 상세 조회 기능 구현
- BookPage에서 붕어빵 클릭 시 상세 페이지 이동 기능 추가
- 공통 CloseButton 컴포넌트 생성 및 적용
- fetchBookDetailData API 연동하여 상세 데이터 가져오기

**주요 변경 사항**
- /bookDetailPage/:flavorId 라우트 추가
- goToFishDetail(fishId) 함수 추가 (붕어빵 클릭 시 상세 페이지 이동)
- CloseButton 컴포넌트 적용하여 코드 중복 제거