### PR TITLE
[fix] 화면 이동 로직, 일지 편집의 글자 밑 줄 개수 수정

### DIFF
--- a/src/pages/detail/DetailPage.js
+++ b/src/pages/detail/DetailPage.js
@@ -173,7 +173,7 @@ function DetailsPage() {
                   value={editedContent}
                   onChange={(e) => setEditedContent(e.target.value)}
                   className="relative z-10 break-all w-full rounded-md bg-white text-sz30 leading-[2rem] focus:outline-none focus:border-[2px]"
-                  rows="7" // 필요에 따라 행 수 조절
+                  rows="5" // 필요에 따라 행 수 조절
                   style={{
                     background:
                       "repeating-linear-gradient(to bottom, transparent, transparent calc(2rem - 1px), #ccc calc(2rem - 1px), #ccc 2rem)",

--- a/src/pages/register/add/AddPage.js
+++ b/src/pages/register/add/AddPage.js
@@ -196,7 +196,7 @@ const AddPage = () => {
 
   const handleClose = () => {
     //메인 페이지로 네비게이트
-    navigate("/main");
+    navigate(-1);
   };
 
   return (

--- a/src/pages/register/success/SuccessPage.js
+++ b/src/pages/register/success/SuccessPage.js
@@ -42,7 +42,7 @@ function SuccessPage() {
   };
 
   const handleConfirm = () => {
-    navigate("/main");
+    navigate(-2);
   };
 
   const handleSlideChange = (swiper) => {
@@ -71,9 +71,8 @@ function SuccessPage() {
         {Array.from({ length: total }, (_, index) => (
           <span
             key={index}
-            className={`w-3 h-3 rounded-full cursor-pointer transition-all ${
-              index === activeIndex ? "bg-[#7f5b41] scale-125" : "bg-gray-300"
-            }`}
+            className={`w-3 h-3 rounded-full cursor-pointer transition-all ${index === activeIndex ? "bg-[#7f5b41] scale-125" : "bg-gray-300"
+              }`}
             onClick={() => onDotClick(index)} // 클릭 시 활성화된 슬라이드 변경
           ></span>
         ))}
@@ -125,11 +124,10 @@ function SuccessPage() {
                     <img
                       src={`/assets/webp/flavorIcons/${item.iconCode}.webp`}
                       alt={item.flavor}
-                      className={`w-full h-full object-contain ${
-                        activeIndex === index && animationTrigger
-                          ? "animate__animated animate__bounce"
-                          : ""
-                      }`}
+                      className={`w-full h-full object-contain ${activeIndex === index && animationTrigger
+                        ? "animate__animated animate__bounce"
+                        : ""
+                        }`}
                       onError={(e) => {
                         e.target.src = "/assets/webp/flavorIcons/notYet.webp"; // 기본 이미지 경로로 대체
                       }}


### PR DESCRIPTION
- 일지 편집 창에서 문장 밑에 줄 수 5개로 수정
- 등록을 하지 않고 닫기 버튼을 누르면 이전 페이지로 돌아가도록 수정
    - 메인페이지에서 등록하면 메인페이지로, 일지에서 등록하면 일지로 돌아가도록 수정