### PR TITLE
[feat] myRating 기반 모달 기본값 설정 및 '평점 없음' 표시

### DIFF
--- a/src/components/StarRating/StarRating.jsx
+++ b/src/components/StarRating/StarRating.jsx
@@ -8,7 +8,7 @@ const StarRating = ({ avgRating, flavorId, refreshData, myRating }) => {
   const [isModalOpen, setIsModalOpen] = useState(false); // 모달 상태
 
   const openModal = () => {
-    setTempRating(rating); // 기존 별점 유지
+    setTempRating(myRating ?? 0); // 기존 별점 유지
     setIsModalOpen(true);
   };
 

--- a/src/components/StarRating/StarRating.jsx
+++ b/src/components/StarRating/StarRating.jsx
@@ -53,7 +53,11 @@ const StarRating = ({ avgRating, flavorId, refreshData, myRating }) => {
           starDimension="25px"
           starSpacing="5px"
         />
-        <div className="text-sz22 font-semibold pt-1">{rating.toFixed(1)}점</div>
+        <div className="text-sz22 font-semibold pt-1">
+          {(avgRating === null || avgRating === 0)
+            ? "평점 없음"
+            : `${rating.toFixed(1)}점`}
+        </div>
       </div>
 
       {isModalOpen && (


### PR DESCRIPTION
### 변경 내용
- 별점 모달을 열 때 기본값을 avgRating 대신 myRating으로 설정
- 사용자가 별점을 한 번도 주지 않은 경우, 0점 대신 '평점 없음' 문구 표시